### PR TITLE
feat(cloud): add UserService.GetAllUsers(ctx) wrapper for full user enumeration

### DIFF
--- a/cloud/user.go
+++ b/cloud/user.go
@@ -209,6 +209,25 @@ func (s *UserService) GetCurrentUser(ctx context.Context) (*User, *Response, err
 	return &user, resp, nil
 }
 
+// GetAllUsers a list of all users, including active users, inactive users and previously deleted users that have an Atlassian account.
+//
+// JIRA API docs: https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-users/#api-rest-api-2-users-search-get
+func (s *UserService) GetAllUsers(ctx context.Context) ([]User, *Response, error) {
+	const apiEndpoint = "rest/api/2/users/search"
+	req, err := s.client.NewRequest(ctx, http.MethodGet, apiEndpoint, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var users []User
+	resp, err := s.client.Do(req, &users)
+	if err != nil {
+		return nil, resp, NewJiraError(resp, err)
+	}
+
+	return users, resp, nil
+}
+
 // WithMaxResults sets the max results to return
 func WithMaxResults(maxResults int) UserSearchF {
 	return func(s UserSearch) UserSearch {
@@ -268,7 +287,7 @@ func WithProperty(property string) UserSearchF {
 // Find searches for user info from Jira:
 // It can find users by email or display name using the query parameter
 //
-// Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/v2/#api-rest-api-2-user-search-get
+// Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-user-search/#api-rest-api-2-user-search-get
 //
 // TODO Double check this method if this works as expected, is using the latest API and the response is complete
 // This double check effort is done for v2 - Remove this two lines if this is completed.

--- a/cloud/user.go
+++ b/cloud/user.go
@@ -209,11 +209,11 @@ func (s *UserService) GetCurrentUser(ctx context.Context) (*User, *Response, err
 	return &user, resp, nil
 }
 
-// GetAllUsers a list of all users, including active users, inactive users and previously deleted users that have an Atlassian account.
+// GetAllUsers returns a list of all users, including active users, inactive users and previously deleted users that have an Atlassian account.
 //
-// JIRA API docs: https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-users/#api-rest-api-2-users-search-get
+// JIRA API docs: https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-users/#api-rest-api-2-users-get
 func (s *UserService) GetAllUsers(ctx context.Context) ([]User, *Response, error) {
-	const apiEndpoint = "rest/api/2/users/search"
+	const apiEndpoint = "rest/api/2/users"
 	req, err := s.client.NewRequest(ctx, http.MethodGet, apiEndpoint, nil)
 	if err != nil {
 		return nil, nil, err

--- a/cloud/user_test.go
+++ b/cloud/user_test.go
@@ -282,3 +282,26 @@ func TestUserService_Find_SuccessParams(t *testing.T) {
 		t.Error("Expected user. User is nil")
 	}
 }
+
+func TestUserService_GetAllUsers_SuccessParams(t *testing.T) {
+	setup()
+	defer teardown()
+	testMux.HandleFunc("/rest/api/2/users", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		testRequestURL(t, r, "/rest/api/2/users")
+
+		fmt.Fprint(w, `[{"self":"http://www.example.com/jira/rest/api/2/users","key":"fred",
+        "name":"fred","emailAddress":"fred@example.com","avatarUrls":{"48x48":"http://www.example.com/jira/secure/useravatar?size=large&ownerId=fred",
+        "24x24":"http://www.example.com/jira/secure/useravatar?size=small&ownerId=fred","16x16":"http://www.example.com/jira/secure/useravatar?size=xsmall&ownerId=fred",
+        "32x32":"http://www.example.com/jira/secure/useravatar?size=medium&ownerId=fred"},"displayName":"Fred F. User","active":true,"timeZone":"Australia/Sydney","groups":{"size":3,"items":[
+        {"name":"jira-user","self":"http://www.example.com/jira/rest/api/2/group?groupname=jira-user"},{"name":"jira-admin",
+        "self":"http://www.example.com/jira/rest/api/2/group?groupname=jira-admin"},{"name":"important","self":"http://www.example.com/jira/rest/api/2/group?groupname=important"
+        }]},"applicationRoles":{"size":1,"items":[]},"expand":"groups,applicationRoles"}]`)
+	})
+
+	if user, _, err := testClient.User.GetAllUsers(context.Background()); err != nil {
+		t.Errorf("Error given: %s", err)
+	} else if user == nil {
+		t.Error("Expected user. User is nil")
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

* feature

#### What this PR does / why we need it:

Jira exposes [get all users](https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-users/#api-rest-api-2-users-get) endpoints distinct from [user search](https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-user-search/#api-rest-api-2-user-search-get). Search endpoints are better for interactive/fuzzy lookup and have different behavior/limits. Adding a distinct `GetAllUsers` avoids mixing search semantics with full user enumeration.

#### Which issue(s) this PR fixes:

No issue, I am currently using go-jira with custom wrappers and thought this would be useful.

#### Special notes for your reviewer:

Great project, keep up the good work!

